### PR TITLE
Add geolocation-based content blocking for Thailand

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -1,8 +1,9 @@
 ---
 layout: default
 ---
-<div class="post">
-  <header class="post-header">
+<div id="geo-gate" style="visibility: hidden">
+  <div class="post">
+    <header class="post-header">
     <h1 class="post-title">
       {% if site.title == 'blank' %}
         <span class="font-weight-bold">{{ site.first_name }}</span> {{ site.middle_name }}
@@ -77,4 +78,7 @@ layout: default
       {% include newsletter.liquid center=true %}
     {% endif %}
   </article>
+  </div>
 </div>
+
+<script src="{{ '/assets/js/geo_block.js' | relative_url | bust_file_cache }}"></script>

--- a/assets/js/geo_block.js
+++ b/assets/js/geo_block.js
@@ -1,0 +1,38 @@
+/*
+  Hides the homepage content for visitors whose IP address geolocates to Thailand.
+  The content is hidden by default via inline style (see about.liquid) to avoid a
+  flash of content before this script runs; it is only revealed once we've confirmed
+  the visitor is NOT in Thailand, or if the geolocation lookup fails (fail-open).
+*/
+(function () {
+  var gate = document.getElementById('geo-gate');
+  if (!gate) return;
+
+  var revealed = false;
+  function reveal() {
+    if (revealed) return;
+    revealed = true;
+    gate.style.visibility = 'visible';
+  }
+
+  // Fail-open safeguard: never leave the page blank forever if the geolocation
+  // service is slow, blocked, or unavailable.
+  var fallbackTimer = setTimeout(reveal, 4000);
+
+  fetch('https://ipapi.co/json/', { cache: 'no-store' })
+    .then(function (response) {
+      return response.json();
+    })
+    .then(function (data) {
+      clearTimeout(fallbackTimer);
+      if (data && data.country_code === 'TH') {
+        // Leave the content hidden for Thailand-based visitors.
+        return;
+      }
+      reveal();
+    })
+    .catch(function () {
+      clearTimeout(fallbackTimer);
+      reveal();
+    });
+})();


### PR DESCRIPTION
## Summary
This PR implements geolocation-based content blocking to hide the about page for visitors whose IP addresses geolocate to Thailand, while maintaining a fail-open approach to ensure content is always accessible if the geolocation service is unavailable.

## Key Changes
- **New geolocation script** (`assets/js/geo_block.js`): Fetches visitor IP geolocation data from ipapi.co and conditionally reveals page content based on country code
- **Updated about page layout** (`_layouts/about.liquid`): Wrapped content in a hidden container (`geo-gate`) that is revealed by the geolocation script, with inline styles preventing flash of content before script execution
- **Fail-open safeguard**: Implements a 4-second timeout that automatically reveals content if the geolocation service is slow, blocked, or unavailable

## Implementation Details
- Content is hidden by default via `visibility: hidden` inline style to prevent a flash of content before the script runs
- The geolocation check uses the ipapi.co API with `cache: 'no-store'` to ensure fresh lookups
- If the visitor's country code is 'TH' (Thailand), content remains hidden; otherwise it is revealed
- Both error cases (API failure) and timeout cases trigger the fail-open reveal mechanism
- Uses an IIFE pattern to avoid polluting the global scope

https://claude.ai/code/session_012PvEYTJepEDd9aBSvhJQgn